### PR TITLE
Fixes unit test EOL differences between different OS

### DIFF
--- a/tests/license-sniffer.tests.js
+++ b/tests/license-sniffer.tests.js
@@ -1,6 +1,7 @@
 var assert = require("assert");
 var path = require("path");
 var fs = require("fs");
+var EOL = require("os").EOL;
 
 var mkdirp = require("mkdirp");
 var temp = require("temp");
@@ -11,7 +12,7 @@ var licenseSniffer = require("../");
 
 describe("license-sniffer.sniff", function() {
     this.timeout(5000);
-    
+
     it("detects itself as BSD", function(done) {
         licenseSniffer.sniff(path.join(__dirname, ".."), function(err, license) {
             assert.ifError(err);
@@ -19,7 +20,7 @@ describe("license-sniffer.sniff", function() {
             done();
         });
     });
-    
+
     it("includes license text from LICENSE if present", function(done) {
         licenseSniffer.sniff(path.join(__dirname, ".."), function(err, license) {
             assert.ifError(err);
@@ -27,7 +28,7 @@ describe("license-sniffer.sniff", function() {
             done();
         });
     });
-    
+
     it("uses license template if package.json contains license but LICENSE does not exist", function(done) {
         withTemporaryModule("test-module", function(moduleDirPath) {
             fs.writeFileSync(
@@ -37,14 +38,14 @@ describe("license-sniffer.sniff", function() {
             licenseSniffer.sniff(moduleDirPath, function(err, license) {
                 assert.ifError(err);
                 var expectedPrefix =
-                    "Copyright (c) 2013 test-module\n\n" +
+                    "Copyright (c) 2013 test-module" + EOL + EOL +
                     "Permission is hereby granted";
                 assert.equal(license.text.substring(0, expectedPrefix.length), expectedPrefix);
                 done();
-            }); 
+            });
         });
     });
-    
+
     it("uses license alias to find license template", function(done) {
         withTemporaryModule("test-module", function(moduleDirPath) {
             fs.writeFileSync(
@@ -54,23 +55,23 @@ describe("license-sniffer.sniff", function() {
             licenseSniffer.sniff(moduleDirPath, function(err, license) {
                 assert.ifError(err);
                 var expectedPrefix =
-                    "Copyright (c) 2013, test-module\n" +
+                    "Copyright (c) 2013, test-module" + EOL +
                     "All rights reserved.";
                 assert.equal(license.text.substring(0, expectedPrefix.length), expectedPrefix);
                 done();
-            }); 
+            });
         });
     });
-    
-    
-    
+
+
+
     it("errors if package.json doesn't exist", function(done) {
         licenseSniffer.sniff(__dirname, function(err, license) {
             assert.ok(err);
             done();
         });
     });
-    
+
     it("detects BSD license using LICENSE file if present", function(done) {
         withTemporaryModule("test-module", function(moduleDirPath) {
             var bsdLicenseText = licenseText("bsd-2-clause");
@@ -79,10 +80,10 @@ describe("license-sniffer.sniff", function() {
                 assert.ifError(err);
                 assert.deepEqual(license.names, ["BSD 2-Clause"]);
                 done();
-            }); 
+            });
         });
     });
-    
+
     it("detects MIT license using LICENSE file if present", function(done) {
         withTemporaryModule("test-module", function(moduleDirPath) {
             var mitLicenseText = licenseText("mit");
@@ -91,10 +92,10 @@ describe("license-sniffer.sniff", function() {
                 assert.ifError(err);
                 assert.deepEqual(license.names, ["MIT"]);
                 done();
-            }); 
+            });
         });
     });
-    
+
     it("includes license text when detecting licence using LICENSE file", function(done) {
         withTemporaryModule("test-module", function(moduleDirPath) {
             // Add a bit on the end to make sure we're actually reading from the module
@@ -107,7 +108,7 @@ describe("license-sniffer.sniff", function() {
             });
         });
     });
-    
+
     it("detects unlicense using UNLICENSE file if present", function(done) {
         withTemporaryModule("test-module", function(moduleDirPath) {
             var unlicenseText = licenseText("unlicense");
@@ -116,10 +117,10 @@ describe("license-sniffer.sniff", function() {
                 assert.ifError(err);
                 assert.deepEqual(license.names, ["Public domain"]);
                 done();
-            }); 
+            });
         });
     });
-    
+
     it("detects no license if LICENSE is not similar to any known license", function(done) {
         withTemporaryModule("test-module", function(moduleDirPath) {
             fs.writeFile(path.join(moduleDirPath, "LICENSE"), "Been Listening");
@@ -130,7 +131,7 @@ describe("license-sniffer.sniff", function() {
             });
         });
     });
-    
+
     it("detects license text if included in README.md", function(done) {
         withTemporaryModule("test-module", function(moduleDirPath) {
             fs.writeFile(path.join(moduleDirPath, "README.md"), "## License\n\n" + licenseText("mit"));
@@ -141,11 +142,11 @@ describe("license-sniffer.sniff", function() {
             });
         });
     });
-    
+
     it("only considers text in README.md following 'License' header", function(done) {
         withTemporaryModule("test-module", function(moduleDirPath) {
             var readmeJunk = new Array(1000).join("rabbit ");
-            
+
             var readmeContents = "license\n\n## Introduction\n\n" + readmeJunk + "\n\n## License\n\n" + licenseText("mit");
             fs.writeFile(path.join(moduleDirPath, "README.md"), readmeContents);
             licenseSniffer.sniff(moduleDirPath, function(err, license) {
@@ -155,11 +156,11 @@ describe("license-sniffer.sniff", function() {
             });
         });
     });
-    
+
     it("ignores text after license", function(done) {
         withTemporaryModule("test-module", function(moduleDirPath) {
             var readmeJunk = new Array(1000).join("rabbit ");
-            
+
             var readmeContents = "## License\n\n" + licenseText("mit") + "\n\n##The rest\n\n" + readmeJunk;
             fs.writeFile(path.join(moduleDirPath, "README.md"), readmeContents);
             licenseSniffer.sniff(moduleDirPath, function(err, license) {
@@ -169,7 +170,7 @@ describe("license-sniffer.sniff", function() {
             });
         });
     });
-    
+
     it("can find readme.md when not all uppercase", function(done) {
         withTemporaryModule("test-module", function(moduleDirPath) {
             fs.writeFile(path.join(moduleDirPath, "Readme.md"), "## License\n\n" + licenseText("mit"));
@@ -204,7 +205,7 @@ describe("license-sniffer.sniffPackageJson", function() {
             done();
         });
     });
-    
+
     it("reads license field", function(done) {
         licenseSniffer.sniffPackageJson({license: "BSD"}, function(err, license) {
             assert.ifError(err);
@@ -212,7 +213,7 @@ describe("license-sniffer.sniffPackageJson", function() {
             done();
         });
     });
-    
+
     it("packageJson is parsed to JSON object if its a string", function(done) {
         licenseSniffer.sniffPackageJson('{"license": "BSD"}', function(err, license) {
             assert.ifError(err);
@@ -220,14 +221,14 @@ describe("license-sniffer.sniffPackageJson", function() {
             done();
         });
     });
-    
+
     it("passes error to callback if JSON is badly formed", function(done) {
         licenseSniffer.sniffPackageJson('{license: "BSD"}', function(err, license) {
             assert.ok(err);
             done();
         });
     });
-    
+
     it("reads licenses field if license field is not present", function(done) {
         var packageJson = {
             licenses: [
@@ -243,7 +244,7 @@ describe("license-sniffer.sniffPackageJson", function() {
             done();
         });
     });
-    
+
     it("license field can be object", function(done) {
         var packageJson = {
             license: {
@@ -257,7 +258,7 @@ describe("license-sniffer.sniffPackageJson", function() {
             done();
         });
     });
-    
+
     it("reads multiple licenses if licenses has many elements", function(done) {
         var packageJson = {
             licenses: [{type: "BSD"}, {type: "MIT"}]


### PR DESCRIPTION
using require('os').EOL instead of '\n' in unit test
